### PR TITLE
1.21.1 support

### DIFF
--- a/StaffPlusPlusCraftbukkitAPI/pom.xml
+++ b/StaffPlusPlusCraftbukkitAPI/pom.xml
@@ -13,6 +13,8 @@
 
     <properties>
         <maven.deploy.skip>false</maven.deploy.skip>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>

--- a/StaffPlusPlusCraftbukkitAPI/pom.xml
+++ b/StaffPlusPlusCraftbukkitAPI/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.0</version>
+        <version>1.21.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/StaffPlusPlusCraftbukkitAPI/src/main/java/be/garagepoort/staffplusplus/craftbukkit/api/JsonSenderFactory.java
+++ b/StaffPlusPlusCraftbukkitAPI/src/main/java/be/garagepoort/staffplusplus/craftbukkit/api/JsonSenderFactory.java
@@ -36,6 +36,7 @@ public class JsonSenderFactory {
             case "1.20.6-R0.1":
                 return new JsonSender_v1_20_R4();
             case "1.21-R0.1":
+            case "1.21.1-R0.1":
                 return new JsonSender_v1_21_R0();
             default:
                 throw new RuntimeException("No suitable protocol version found for: " + version + ". Are you sure this version of minecraft is supported?");

--- a/StaffPlusPlusCraftbukkitAPI/src/main/java/be/garagepoort/staffplusplus/craftbukkit/api/ProtocolFactory.java
+++ b/StaffPlusPlusCraftbukkitAPI/src/main/java/be/garagepoort/staffplusplus/craftbukkit/api/ProtocolFactory.java
@@ -62,6 +62,7 @@ public class ProtocolFactory {
             case "1.20.6-R0.1":
                 return new Protocol_v1_20_R4();
             case "1.21-R0.1":
+            case "1.21.1-R0.1":
                 return new Protocol_v1_21_R0();
             default:
                 throw new RuntimeException("No suitable protocol version found for: " + version + ". Are you sure this version of minecraft is supported?");

--- a/StaffPlusPlusCraftbukkitCommon/pom.xml
+++ b/StaffPlusPlusCraftbukkitCommon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.0</version>
+        <version>1.21.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/StaffPlusPlusCraftbukkitCommon/pom.xml
+++ b/StaffPlusPlusCraftbukkitCommon/pom.xml
@@ -12,6 +12,8 @@
     <artifactId>StaffPlusPlusCraftbukkitCommon</artifactId>
     <properties>
         <maven.deploy.skip>false</maven.deploy.skip>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <description>Compatibility module for use of craftbukki's internal api</description>
     <artifactId>StaffPlusPlusCraftBukkit</artifactId>
     <packaging>pom</packaging>
-    <version>1.21.0</version>
+    <version>1.21.1</version>
 
     <modules>
         <module>StaffPlusPlusCraftbukkitCommon</module>

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,13 @@
     <packaging>pom</packaging>
     <version>1.21.1</version>
 
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
     <modules>
         <module>StaffPlusPlusCraftbukkitCommon</module>
         <module>v1_12_R1</module>
@@ -51,11 +58,6 @@
             </plugin>
         </plugins>
     </build>
-
-    <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-    </properties>
 
     <repositories>
         <repository>

--- a/v1_12_R1/pom.xml
+++ b/v1_12_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.0</version>
+        <version>1.21.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_13_R1/pom.xml
+++ b/v1_13_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.0</version>
+        <version>1.21.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_13_R2/pom.xml
+++ b/v1_13_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.0</version>
+        <version>1.21.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_14_R1/pom.xml
+++ b/v1_14_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.0</version>
+        <version>1.21.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_14_R2/pom.xml
+++ b/v1_14_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.0</version>
+        <version>1.21.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_15_R1/pom.xml
+++ b/v1_15_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.0</version>
+        <version>1.21.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_16_R1/pom.xml
+++ b/v1_16_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.0</version>
+        <version>1.21.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_16_R2/pom.xml
+++ b/v1_16_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.0</version>
+        <version>1.21.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_16_R3/pom.xml
+++ b/v1_16_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.0</version>
+        <version>1.21.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_17_R0/pom.xml
+++ b/v1_17_R0/pom.xml
@@ -12,8 +12,9 @@
     <artifactId>v1_17_R0</artifactId>
 
     <properties>
-
         <spigot.version>1.17-R0.1-SNAPSHOT</spigot.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>

--- a/v1_17_R0/pom.xml
+++ b/v1_17_R0/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.0</version>
+        <version>1.21.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_18_R0/pom.xml
+++ b/v1_18_R0/pom.xml
@@ -12,8 +12,9 @@
     <artifactId>v1_18_R0</artifactId>
 
     <properties>
-
         <spigot.version>1.18-R0.1-SNAPSHOT</spigot.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>

--- a/v1_18_R0/pom.xml
+++ b/v1_18_R0/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.0</version>
+        <version>1.21.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_18_R1/pom.xml
+++ b/v1_18_R1/pom.xml
@@ -12,8 +12,9 @@
     <artifactId>v1_18_R1</artifactId>
 
     <properties>
-
         <spigot.version>1.18.2-R0.1-SNAPSHOT</spigot.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>

--- a/v1_18_R1/pom.xml
+++ b/v1_18_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.0</version>
+        <version>1.21.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_19_R0/pom.xml
+++ b/v1_19_R0/pom.xml
@@ -12,8 +12,9 @@
     <artifactId>v1_19_R0</artifactId>
 
     <properties>
-
         <spigot.version>1.19-R0.1-SNAPSHOT</spigot.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>

--- a/v1_19_R0/pom.xml
+++ b/v1_19_R0/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.0</version>
+        <version>1.21.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_19_R1/pom.xml
+++ b/v1_19_R1/pom.xml
@@ -13,6 +13,8 @@
 
     <properties>
         <spigot.version>1.19.2-R0.1-SNAPSHOT</spigot.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>

--- a/v1_19_R1/pom.xml
+++ b/v1_19_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.0</version>
+        <version>1.21.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_19_R2/pom.xml
+++ b/v1_19_R2/pom.xml
@@ -13,6 +13,8 @@
 
     <properties>
         <spigot.version>1.19.3-R0.1-SNAPSHOT</spigot.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>

--- a/v1_19_R2/pom.xml
+++ b/v1_19_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.0</version>
+        <version>1.21.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_19_R3/pom.xml
+++ b/v1_19_R3/pom.xml
@@ -13,6 +13,8 @@
 
     <properties>
         <spigot.version>1.19.4-R0.1-SNAPSHOT</spigot.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>

--- a/v1_19_R3/pom.xml
+++ b/v1_19_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.0</version>
+        <version>1.21.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_20_R0/pom.xml
+++ b/v1_20_R0/pom.xml
@@ -12,8 +12,9 @@
     <artifactId>v1_20_R0</artifactId>
 
     <properties>
-
         <spigot.version>1.20.1-R0.1-SNAPSHOT</spigot.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>

--- a/v1_20_R0/pom.xml
+++ b/v1_20_R0/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.0</version>
+        <version>1.21.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_20_R2/pom.xml
+++ b/v1_20_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.0</version>
+        <version>1.21.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_20_R2/pom.xml
+++ b/v1_20_R2/pom.xml
@@ -12,8 +12,9 @@
     <artifactId>v1_20_R2</artifactId>
 
     <properties>
-
         <spigot.version>1.20.2-R0.1-SNAPSHOT</spigot.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>

--- a/v1_20_R3/pom.xml
+++ b/v1_20_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.0</version>
+        <version>1.21.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_20_R3/pom.xml
+++ b/v1_20_R3/pom.xml
@@ -12,8 +12,9 @@
     <artifactId>v1_20_R3</artifactId>
 
     <properties>
-
         <spigot.version>1.20.4-R0.1-SNAPSHOT</spigot.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>

--- a/v1_20_R4/pom.xml
+++ b/v1_20_R4/pom.xml
@@ -12,8 +12,9 @@
     <artifactId>v1_20_R4</artifactId>
 
     <properties>
-
         <spigot.version>1.20.6-R0.1-SNAPSHOT</spigot.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>

--- a/v1_20_R4/pom.xml
+++ b/v1_20_R4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.0</version>
+        <version>1.21.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_21_R0/pom.xml
+++ b/v1_21_R0/pom.xml
@@ -13,6 +13,8 @@
 
     <properties>
         <spigot.version>1.21-R0.1-SNAPSHOT</spigot.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>

--- a/v1_21_R0/pom.xml
+++ b/v1_21_R0/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.0</version>
+        <version>1.21.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Add support for protocol `1.21.1-R0.1`.

There were no changes that affected us (protocol version was not changed).
The 1.21.1 remapped jar files are not needed for building.