### PR TITLE
Add 26.1.x support

### DIFF
--- a/StaffPlusPlusCraftbukkitAPI/pom.xml
+++ b/StaffPlusPlusCraftbukkitAPI/pom.xml
@@ -193,5 +193,10 @@
             <version>${project.parent.version}</version>
             <classifier>remapped-spigot</classifier>
         </dependency>
+        <dependency>
+            <groupId>net.shortninja.staffplus</groupId>
+            <artifactId>v26_1_R0</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/StaffPlusPlusCraftbukkitAPI/pom.xml
+++ b/StaffPlusPlusCraftbukkitAPI/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/StaffPlusPlusCraftbukkitAPI/src/main/java/be/garagepoort/staffplusplus/craftbukkit/api/JsonSenderFactory.java
+++ b/StaffPlusPlusCraftbukkitAPI/src/main/java/be/garagepoort/staffplusplus/craftbukkit/api/JsonSenderFactory.java
@@ -48,12 +48,18 @@ public class JsonSenderFactory {
                 return new JsonSender_v1_21_R3();
             case "1.21.6-R0.1":
                 return new JsonSender_v1_21_R4();
-            case "1.21.7-R0.1", "1.21.8-R0.1":
+            case "1.21.7-R0.1":
+            case "1.21.8-R0.1":
                 return new JsonSender_v1_21_R5();
-            case "1.21.9-R0.1", "1.21.10-R0.1":
+            case "1.21.9-R0.1":
+            case "1.21.10-R0.1":
                 return new JsonSender_v1_21_R6();
             case "1.21.11-R0.1":
                 return new JsonSender_v1_21_R7();
+            case "26.1-R0.1":
+            case "26.1.1-R0.1":
+            case "26.1.2-R0.1":
+                return new JsonSender_v26_1_R0();
             default:
                 throw new UnsupportedVersionException(version);
         }

--- a/StaffPlusPlusCraftbukkitAPI/src/main/java/be/garagepoort/staffplusplus/craftbukkit/api/JsonSenderFactory.java
+++ b/StaffPlusPlusCraftbukkitAPI/src/main/java/be/garagepoort/staffplusplus/craftbukkit/api/JsonSenderFactory.java
@@ -8,10 +8,9 @@ import org.bukkit.Bukkit;
 public class JsonSenderFactory {
 
     public static JsonSender getSender() {
-        final String version = Bukkit.getBukkitVersion();
-        final String versionWithoutSnapshot = version.replaceAll("-SNAPSHOT", "");
+        final String version = VersionUtil.getMcVersion();
 
-        switch (versionWithoutSnapshot) {
+        switch (version) {
             case "1.17-R0.1":
                 return new JsonSender_v1_17_R0();
             case "1.18-R0.1":

--- a/StaffPlusPlusCraftbukkitAPI/src/main/java/be/garagepoort/staffplusplus/craftbukkit/api/ProtocolFactory.java
+++ b/StaffPlusPlusCraftbukkitAPI/src/main/java/be/garagepoort/staffplusplus/craftbukkit/api/ProtocolFactory.java
@@ -74,12 +74,18 @@ public class ProtocolFactory {
                 return new Protocol_v1_21_R3();
             case "1.21.6-R0.1":
                 return new Protocol_v1_21_R4();
-            case "1.21.7-R0.1", "1.21.8-R0.1":
+            case "1.21.7-R0.1":
+            case "1.21.8-R0.1":
                 return new Protocol_v1_21_R5();
-            case "1.21.9-R0.1", "1.21.10-R0.1":
+            case "1.21.9-R0.1":
+            case "1.21.10-R0.1":
                 return new Protocol_v1_21_R6();
             case "1.21.11-R0.1":
                 return new Protocol_v1_21_R7();
+            case "26.1-R0.1":
+            case "26.1.1-R0.1":
+            case "26.1.2-R0.1":
+                return new Protocol_v26_1_R0();
             default:
                 throw new UnsupportedVersionException(version);
         }

--- a/StaffPlusPlusCraftbukkitAPI/src/main/java/be/garagepoort/staffplusplus/craftbukkit/api/ProtocolFactory.java
+++ b/StaffPlusPlusCraftbukkitAPI/src/main/java/be/garagepoort/staffplusplus/craftbukkit/api/ProtocolFactory.java
@@ -13,9 +13,9 @@ import org.bukkit.Bukkit;
 public class ProtocolFactory {
 
     public static IProtocol getProtocol() {
-        final String version = Bukkit.getBukkitVersion();
-        final String versionWithoutSnapshot = version.replaceAll("-SNAPSHOT", "");
-        switch (versionWithoutSnapshot) {
+        final String version = VersionUtil.getMcVersion();
+
+        switch (version) {
             case "1.12.1-R0.1":
             case "1.12.2-R0.1":
                 return new Protocol_v1_12_R1();

--- a/StaffPlusPlusCraftbukkitAPI/src/main/java/be/garagepoort/staffplusplus/craftbukkit/api/VersionUtil.java
+++ b/StaffPlusPlusCraftbukkitAPI/src/main/java/be/garagepoort/staffplusplus/craftbukkit/api/VersionUtil.java
@@ -1,0 +1,36 @@
+package be.garagepoort.staffplusplus.craftbukkit.api;
+
+import org.bukkit.Bukkit;
+
+import java.lang.ReflectiveOperationException;
+import java.lang.reflect.Method;
+
+final class VersionUtil {
+    private static final String SERVER_VERSION = parseServerVersion();
+    
+    public static String getMcVersion() {
+        return SERVER_VERSION;
+    }
+    
+    private static String parseServerVersion() {
+        // Paper's implementation of Bukkit.getBukkitVersion() returns a different format than spigot
+        // this method attempts to use paper API to get the server version if paper is found
+        // otherwise fallbacks to parsing Bukkit.getBukkitVersion(), with the assumption that the server is not paper
+        
+        try {
+            Class<?> clazz = Class.forName("io.papermc.paper.ServerBuildInfo");
+            
+            Method buildInfo = clazz.getMethod("buildInfo");
+            Object info = buildInfo.invoke(null); // static
+            
+            Method minecraftVersionId = clazz.getMethod("minecraftVersionId");
+            String version = (String) minecraftVersionId.invoke(info);
+            
+            return version + "-R0.1";
+        } catch (ReflectiveOperationException ignored) {
+        }
+        
+        String version = Bukkit.getBukkitVersion().replace("-SNAPSHOT", "");
+        return version;
+    }
+}

--- a/StaffPlusPlusCraftbukkitCommon/pom.xml
+++ b/StaffPlusPlusCraftbukkitCommon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <module>v1_21_R5</module>
         <module>v1_21_R6</module>
         <module>v1_21_R7</module>
+        <module>v26_1_R0</module>
         <module>StaffPlusPlusCraftbukkitAPI</module>
     </modules>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <description>Compatibility module for use of craftbukki's internal api</description>
     <artifactId>StaffPlusPlusCraftBukkit</artifactId>
     <packaging>pom</packaging>
-    <version>1.21.10</version>
+    <version>26.1.0</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/v1_12_R1/pom.xml
+++ b/v1_12_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_13_R1/pom.xml
+++ b/v1_13_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_13_R2/pom.xml
+++ b/v1_13_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_14_R1/pom.xml
+++ b/v1_14_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_14_R2/pom.xml
+++ b/v1_14_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_15_R1/pom.xml
+++ b/v1_15_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_16_R1/pom.xml
+++ b/v1_16_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_16_R2/pom.xml
+++ b/v1_16_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_16_R3/pom.xml
+++ b/v1_16_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_17_R0/pom.xml
+++ b/v1_17_R0/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_18_R0/pom.xml
+++ b/v1_18_R0/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_18_R1/pom.xml
+++ b/v1_18_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_19_R0/pom.xml
+++ b/v1_19_R0/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_19_R1/pom.xml
+++ b/v1_19_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_19_R2/pom.xml
+++ b/v1_19_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_19_R3/pom.xml
+++ b/v1_19_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_20_R0/pom.xml
+++ b/v1_20_R0/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_20_R2/pom.xml
+++ b/v1_20_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_20_R3/pom.xml
+++ b/v1_20_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_20_R4/pom.xml
+++ b/v1_20_R4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_21_R0/pom.xml
+++ b/v1_21_R0/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_21_R1/pom.xml
+++ b/v1_21_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_21_R2/pom.xml
+++ b/v1_21_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_21_R3/pom.xml
+++ b/v1_21_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_21_R4/pom.xml
+++ b/v1_21_R4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_21_R5/pom.xml
+++ b/v1_21_R5/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_21_R6/pom.xml
+++ b/v1_21_R6/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_21_R7/pom.xml
+++ b/v1_21_R7/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v26_1_R0/pom.xml
+++ b/v26_1_R0/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StaffPlusPlusCraftBukkit</artifactId>
         <groupId>net.shortninja.staffplus</groupId>
-        <version>1.21.10</version>
+        <version>26.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v26_1_R0/pom.xml
+++ b/v26_1_R0/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>StaffPlusPlusCraftBukkit</artifactId>
+        <groupId>net.shortninja.staffplus</groupId>
+        <version>1.21.10</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>v26_1_R0</artifactId>
+
+    <properties>
+        <spigot.version>26.1.2-R0.1-SNAPSHOT</spigot.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.shortninja.staffplus</groupId>
+            <artifactId>StaffPlusPlusCraftbukkitCommon</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.shortninja.staffplus</groupId>
+            <artifactId>staffplusplus-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>${spigot.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/v26_1_R0/src/main/java/net/shortninja/staffplus/server/compatibility/v1_1x/JsonSender_v26_1_R0.java
+++ b/v26_1_R0/src/main/java/net/shortninja/staffplus/server/compatibility/v1_1x/JsonSender_v26_1_R0.java
@@ -1,0 +1,39 @@
+package net.shortninja.staffplus.server.compatibility.v1_1x;
+
+import be.garagepoort.staffplusplus.craftbukkit.common.json.rayzr.JSONMessage;
+import be.garagepoort.staffplusplus.craftbukkit.common.json.rayzr.JsonSender;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientboundSystemChatPacket;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
+import org.bukkit.craftbukkit.util.CraftChatMessage;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Method;
+
+public class JsonSender_v26_1_R0 implements JsonSender {
+
+    @Override
+    public void send(JSONMessage jsonMessage, Player...players) {
+        sendPacket(createTextPacket(jsonMessage.toString()), players);
+    }
+
+    private void sendPacket(ClientboundSystemChatPacket packet, Player... players) {
+        if (packet == null) {
+            return;
+        }
+
+        for (Player player : players) {
+            ServerGamePacketListenerImpl serverGamePacketListener = ((CraftPlayer) player).getHandle().connection;
+            serverGamePacketListener.send(packet);
+        }
+    }
+
+    private ClientboundSystemChatPacket createTextPacket(String message) {
+        try {
+            return new ClientboundSystemChatPacket(CraftChatMessage.fromJSON(message), false);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize json packet message. Is it valid JSON?", e);
+        }
+    }
+}

--- a/v26_1_R0/src/main/java/net/shortninja/staffplus/server/compatibility/v1_1x/PacketHandler_v26_1_R0.java
+++ b/v26_1_R0/src/main/java/net/shortninja/staffplus/server/compatibility/v1_1x/PacketHandler_v26_1_R0.java
@@ -1,0 +1,36 @@
+package net.shortninja.staffplus.server.compatibility.v1_1x;
+
+import be.garagepoort.staffplusplus.craftbukkit.common.AbstractPacketHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import net.minecraft.network.protocol.game.ClientboundSoundEntityPacket;
+import net.minecraft.network.protocol.game.ClientboundSoundPacket;
+import net.shortninja.staffplusplus.IStaffPlus;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.RegisteredServiceProvider;
+
+public final class PacketHandler_v26_1_R0 extends AbstractPacketHandler {
+
+    public PacketHandler_v26_1_R0(Player player) {
+        super(player);
+    }
+
+    @Override
+    public boolean onSend(ChannelHandlerContext context, Object o, ChannelPromise promise) {
+        if (o instanceof ClientboundSoundPacket ||
+                o instanceof ClientboundSoundEntityPacket) {
+            RegisteredServiceProvider<IStaffPlus> provider = Bukkit.getServicesManager().getRegistration(IStaffPlus.class);
+            if (provider != null) {
+                return !provider.getProvider().getSessionManager().get(player).isVanished();
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean onReceive(ChannelHandlerContext context, Object o) {
+        return true;
+    }
+}

--- a/v26_1_R0/src/main/java/net/shortninja/staffplus/server/compatibility/v1_1x/Protocol_v26_1_R0.java
+++ b/v26_1_R0/src/main/java/net/shortninja/staffplus/server/compatibility/v1_1x/Protocol_v26_1_R0.java
@@ -1,0 +1,170 @@
+package net.shortninja.staffplus.server.compatibility.v1_1x;
+
+import be.garagepoort.staffplusplus.craftbukkit.common.IProtocol;
+import be.garagepoort.staffplusplus.craftbukkit.common.json.JsonMessage;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelPipeline;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.Connection;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientboundPlayerInfoRemovePacket;
+import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
+import net.minecraft.network.protocol.game.ClientboundSystemChatPacket;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.CustomData;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.craftbukkit.CraftServer;
+import org.bukkit.craftbukkit.command.CraftCommandMap;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
+import org.bukkit.craftbukkit.inventory.CraftItemStack;
+import org.bukkit.craftbukkit.util.CraftChatMessage;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Set;
+
+public class Protocol_v26_1_R0 implements IProtocol {
+    
+    private static final Field CONNECTION_FIELD;
+    
+    static {
+        try {
+            CONNECTION_FIELD = ServerGamePacketListenerImpl.class.getSuperclass().getDeclaredField("connection");
+            CONNECTION_FIELD.setAccessible(true);
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException("Failed to get connection field on ServerGamePacketListenerImpl", e);
+        }
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack addNbtString(org.bukkit.inventory.ItemStack item, String value) {
+        ItemStack craftItem = CraftItemStack.asNMSCopy(item);
+        CustomData defaultData = CustomData.of(new CompoundTag());
+
+        CustomData customData = craftItem.getComponents().getOrDefault(DataComponents.CUSTOM_DATA, defaultData);
+        CompoundTag nbtCompound = customData.copyTag();
+
+        nbtCompound.putString(NBT_IDENTIFIER, value);
+        CustomData.set(DataComponents.CUSTOM_DATA, craftItem, nbtCompound);
+
+        return CraftItemStack.asCraftMirror(craftItem);
+    }
+
+    @Override
+    public String getNbtString(org.bukkit.inventory.ItemStack item) {
+        ItemStack craftItem = CraftItemStack.asNMSCopy(item);
+        if (craftItem == null) {
+            return "";
+        }
+
+        CustomData defaultData = CustomData.of(new CompoundTag());
+        CustomData customData = craftItem.getComponents().getOrDefault(DataComponents.CUSTOM_DATA, defaultData);
+
+        return customData.copyTag().getString(NBT_IDENTIFIER).orElse("");
+    }
+
+    @Override
+    public void unregisterCommand(String match, Command command) {
+        CraftCommandMap commandMap = (CraftCommandMap) ((CraftServer) Bukkit.getServer()).getCommandMap();
+        command.unregister(commandMap);
+
+        String commandName = command.getLabel().toLowerCase();
+        if (commandMap.getKnownCommands().get(commandName) == command) {
+            commandMap.getKnownCommands().remove(commandName);
+        }
+
+        String commandNameWithPrefix = match.toLowerCase() + ":" + commandName;
+        if (commandMap.getKnownCommands().get(commandNameWithPrefix) == command) {
+            commandMap.getKnownCommands().remove(commandNameWithPrefix);
+        }
+
+
+        for (String alias : command.getAliases()) {
+            String aliasName = alias.toLowerCase();
+            String aliasNameWithPrefix = match.toLowerCase() + ":" + aliasName;
+            if (commandMap.getKnownCommands().get(aliasName) == command) {
+                commandMap.getKnownCommands().remove(aliasName);
+            }
+            if (commandMap.getKnownCommands().get(aliasNameWithPrefix) == command) {
+                commandMap.getKnownCommands().remove(aliasNameWithPrefix);
+            }
+        }
+    }
+
+    @Override
+    public void registerCommand(String match, Command command) {
+        ((CraftServer) Bukkit.getServer()).getCommandMap().register(match, command);
+    }
+
+    @Override
+    public void listVanish(Player player, boolean shouldEnable) {
+        Packet packet = null;
+        CraftPlayer craftPlayer = (CraftPlayer) player;
+        ServerPlayer sp = craftPlayer.getHandle();
+
+        if (shouldEnable) {
+            packet = new ClientboundPlayerInfoRemovePacket(List.of(player.getUniqueId()));
+            sendToAllButMe(packet, player);
+        } else {
+            packet = new ClientboundPlayerInfoUpdatePacket(ClientboundPlayerInfoUpdatePacket.Action.ADD_PLAYER, sp);
+            sendToAllButMe(packet, player);
+            packet = new ClientboundPlayerInfoUpdatePacket(ClientboundPlayerInfoUpdatePacket.Action.UPDATE_LISTED, sp);
+            sendToAllButMe(packet, player);
+        }
+    }
+
+    @Override
+    public void sendHoverableJsonMessage(Set<Player> players, String message, String hoverMessage) {
+        JsonMessage json = new JsonMessage().append(message).setHoverAsTooltip(hoverMessage).save();
+        ClientboundSystemChatPacket packet = new ClientboundSystemChatPacket(CraftChatMessage.fromJSON(json.getMessage()), false);
+        for (Player player : players) {
+            Connection o = getConnection(player);
+            o.send(packet);
+        }
+    }
+
+    private static Connection getConnection(Player player) {
+        try {
+            ServerGamePacketListenerImpl serverGamePacketListener = ((CraftPlayer) player).getHandle().connection;
+            return (Connection) CONNECTION_FIELD.get(serverGamePacketListener);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException("Failed to access connection field on ServerGamePacketListenerImpl for " + player.getName(), e);
+        }
+    }
+
+    private void sendToAllButMe(Packet<?> packet, Player me) {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            if (!me.getUniqueId().equals(player.getUniqueId())) {
+                Connection o = getConnection(player);
+                o.send(packet);
+            }
+        }
+    }
+
+    @Override
+    public String getSound(Object object) {
+        return null;
+    }
+
+    @Override
+    public void inject(Player player) {
+        final Connection connection = getConnection(player);
+        final ChannelPipeline pipeline = connection.channel.pipeline();
+
+        pipeline.addBefore("packet_handler", "staffplusplus_" + player.getUniqueId(), new PacketHandler_v26_1_R0(player));
+    }
+
+    @Override
+    public void uninject(Player player) {
+        final Connection connection = getConnection(player);
+        final Channel channel = connection.channel;
+
+        channel.eventLoop().submit(() -> channel.pipeline().remove(player.getUniqueId().toString()));
+    }
+
+}


### PR DESCRIPTION
Adds support for the new Minecraft versions `26.1.x`.

Notable changes:
- Removal of remapping as Mojang now distributes non-obfuscated builds
- Craftbukkit no longer includes protocol version in package path

These changes may allow us to implement a generic compatibility layer for future Minecraft versions that does not require porting on every release (as long as the API is not changed substantially). This is left for the future.